### PR TITLE
Fix flow for if seed is already selected.

### DIFF
--- a/src/seedsigner/views/seed_views.py
+++ b/src/seedsigner/views/seed_views.py
@@ -1873,7 +1873,7 @@ class SeedSignMessageStartView(View):
     
 
     def run(self):
-        if self.seed_num:
+        if self.seed_num is not None:
             # We already know which seed we're signing with
             return Destination(SeedSignMessageConfirmView, skip_current_view=True)
         else:


### PR DESCRIPTION
`if self.seed_num` was evaluating to False for seed_num = 0 when it should be evaluating to True. `if self.seed_num is not None` correctly evaluates seed_num = 0 to True. This fixes the flow so that if a seed is already selected it does not need to be selected again after scanning QR code of message to sign.