### PR TITLE
CI: add pip cache to tests workflow to reduce runtime

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "pip"
+          cache-dependency-path: |
+            requirements.txt
+            tests/requirements.txt
       - name: Install dependencies
         run: |
           sudo apt-get install -y --no-install-recommends libzbar0


### PR DESCRIPTION
Adding pip cache to the tests workflow as discussed in #917 and #920.

Targets your `2026-04-22_CI_hardening` branch per your suggestion.